### PR TITLE
Made code work with production SaaS API

### DIFF
--- a/BillingApiExample/Controllers/BillingController.cs
+++ b/BillingApiExample/Controllers/BillingController.cs
@@ -34,7 +34,7 @@ namespace BillingApiExample.Controllers
             // have to configure your users account accordingly
             // ...
 
-            await service.ActivateSubscription(subscription.SubscriptionId);
+            await service.ActivateSubscription(subscription.SubscriptionId, subscription.PlanId, subscription.Quantity);
         }
 
         [HttpGet("[action]")]
@@ -51,7 +51,14 @@ namespace BillingApiExample.Controllers
             // Alternative: Get the full operation for more details
             var operation = await service.GetOperationStatus(payload.SubscriptionId, payload.OperationId);
 
-            await service.UpdateOperationStatus(payload.SubscriptionId, payload.OperationId, "Success");
+            // Only call UpdateOperationStatus for Reinstate, ChangePlan and ChangeQuantity, otherwise you will get an error from the SaaS API
+            if (payload.Action == MicrosoftOperationAction.Reinstate ||
+                payload.Action == MicrosoftOperationAction.ChangePlan ||
+                payload.Action == MicrosoftOperationAction.ChangeQuantity)
+            {
+                // Update the subscription
+                await service.UpdateOperationStatus(payload.SubscriptionId, payload.OperationId, "Success");
+            }
         }
     }
 }

--- a/BillingApiSdk.Tests/Services/BillingApiServiceTests.cs
+++ b/BillingApiSdk.Tests/Services/BillingApiServiceTests.cs
@@ -9,6 +9,9 @@ namespace BillingApiSdk.Tests.Services
 
     public class BillingApiServiceTests
     {
+        private const string MockSubscriptionId = "37f9dea2-4345-438f-b0bd-03d40d28c7e0";
+        private const string MockOperationId = "74dfb4db-c193-4891-827d-eb05fbdc64b0";
+
         /// <summary>
         /// I know I know, configuration has to be solved in a better way.
         /// You have two options
@@ -53,9 +56,17 @@ namespace BillingApiSdk.Tests.Services
         {
             Task.Run(async () =>
             {
-                // mock subscription id: 37f9dea2-4345-438f-b0bd-03d40d28c7e0
-                var result = await _fixture.GetSubscription("37f9dea2-4345-438f-b0bd-03d40d28c7e0");
+                var result = await _fixture.GetSubscription(MockSubscriptionId);
                 Assert.NotNull(result);
+            }).GetAwaiter().GetResult();
+        }
+
+        [Fact]
+        public void DeleteSubscription_MockApiTest()
+        {
+            Task.Run(async () =>
+            {
+                await _fixture.DeleteSubscription(MockSubscriptionId);
             }).GetAwaiter().GetResult();
         }
 
@@ -64,8 +75,7 @@ namespace BillingApiSdk.Tests.Services
         {
             Task.Run(async () =>
             {
-                // mock subscription id: 37f9dea2-4345-438f-b0bd-03d40d28c7e0
-                var result = await _fixture.GetPendingOperations("37f9dea2-4345-438f-b0bd-03d40d28c7e0");
+                var result = await _fixture.GetPendingOperations(MockSubscriptionId);
                 Assert.NotEmpty(result);
             }).GetAwaiter().GetResult();
         }
@@ -75,8 +85,7 @@ namespace BillingApiSdk.Tests.Services
         {
             Task.Run(async () =>
             {
-                // mock subscription id: 37f9dea2-4345-438f-b0bd-03d40d28c7e0
-                var result = await _fixture.GetOperationStatus("37f9dea2-4345-438f-b0bd-03d40d28c7e0", "74dfb4db-c193-4891-827d-eb05fbdc64b0");
+                var result = await _fixture.GetOperationStatus(MockSubscriptionId, MockOperationId);
                 Assert.NotNull(result);
             }).GetAwaiter().GetResult();
         }

--- a/BillingApiSdk/Models/MicrosoftOperation.cs
+++ b/BillingApiSdk/Models/MicrosoftOperation.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using System;
 
 namespace BillingApiSdk.Models
@@ -69,7 +70,8 @@ namespace BillingApiSdk.Models
         /// - Unsubscribe
         /// </summary>
         [JsonProperty("action")]
-        public string Action { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
+        public MicrosoftOperationAction Action { get; set; }
 
         [JsonProperty("timeStamp")]
         public DateTime TimeStampUtc { get; set; }

--- a/BillingApiSdk/Models/MicrosoftOperationAction.cs
+++ b/BillingApiSdk/Models/MicrosoftOperationAction.cs
@@ -1,0 +1,46 @@
+namespace BillingApiSdk.Models
+{
+    public enum MicrosoftOperationAction
+    {
+        /// (When the resource has been deleted)
+        /// <summary>
+        /// The unsubscribe
+        /// </summary>
+        Unsubscribe,
+
+        /// (When the change plan operation has completed)
+        /// <summary>
+        /// The change plan
+        /// </summary>
+        ChangePlan,
+
+        /// (When the change quantity operation has completed),
+        /// <summary>
+        /// The change quantity
+        /// </summary>
+        ChangeQuantity,
+
+        /// (When resource has been suspended)
+        /// <summary>
+        /// The suspend
+        /// </summary>
+        Suspend,
+
+        /// (When resource has been reinstated after suspension)
+        /// <summary>
+        /// The reinstate
+        /// </summary>
+        Reinstate,
+
+        /// (When resource has been reinstated after suspension)
+        /// <summary>
+        /// The reinstate
+        /// </summary>
+        Renew,
+
+        /// <summary>
+        /// The transfer
+        /// </summary>
+        Transfer,
+    }
+}

--- a/BillingApiSdk/Models/MicrosoftSubscription.cs
+++ b/BillingApiSdk/Models/MicrosoftSubscription.cs
@@ -109,6 +109,12 @@ namespace BillingApiSdk.Models
         public MicrosoftTerm Term { get; set; }
 
         /// <summary>
+        /// Indicating whether the subscription will renew automatically.
+        /// </summary>
+        [JsonProperty("autoRenew")]
+        public bool AutoRenew { get; set; }
+
+        /// <summary>
         /// not relevant
         /// </summary>
         [JsonProperty("isTest")]
@@ -129,10 +135,28 @@ namespace BillingApiSdk.Models
         public List<string> AllowedCustomerOperations { get; set; }
 
         /// <summary>
+        /// The ID of the session that created the subscription.
+        /// </summary>
+        [JsonProperty("sessionId")]
+        public string SessionId { get; set; }
+
+        /// <summary>
+        /// The ID of the fulfillment operation that created the subscription.
+        /// </summary>
+        [JsonProperty("fulfillmentId")]
+        public string FulfillmentId { get; set; }
+
+        /// <summary>
         /// not relevant
         /// </summary>
         [JsonProperty("sandboxType")]
         public string SandboxType { get; set; }
+
+        /// <summary>
+        /// The date and time when the subscription was created.
+        /// </summary>
+        [JsonProperty("created")]
+        public DateTime CreatedDateUtc { get; set; }
 
         /// <summary>
         /// not relevant
@@ -176,7 +200,7 @@ namespace BillingApiSdk.Models
         /// <summary>
         /// Id of the user
         /// </summary>
-        [JsonProperty("pid")]
-        public string Pid { get; set; }
+        [JsonProperty("puid")]
+        public string Puid { get; set; }
     }
 }

--- a/BillingApiSdk/Models/MicrosoftWebhookPayload.cs
+++ b/BillingApiSdk/Models/MicrosoftWebhookPayload.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using System;
 
 namespace BillingApiSdk.Models
@@ -93,12 +94,20 @@ namespace BillingApiSdk.Models
         /// - Unsubscribe
         /// </summary>
         [JsonProperty("action")]
-        public string Action { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
+        public MicrosoftOperationAction Action { get; set; }
 
         /// <summary>
         /// Can be either InProgress or Success
         /// </summary>
         [JsonProperty("status")]
         public string Status { get; set; }
+
+        /// <summary>
+        /// The source of the operation request. 
+        /// </summary>
+        [JsonProperty("operationRequestSource")]
+        public string OperationRequestSource { get; set; }        
+
     }
 }


### PR DESCRIPTION
The existing MicrosoftBillingApi and the accompanying Medium article helped me a lot to get started with the API. 

However, I had to make some changes to the code to get it to work with the production version of the API. As a thanks and to help other users that do not wish to use any of the accelerators, I'd like to share these changes with you.

Some of the changes are:
- The HTTP method for the UpdateOperationStatus call was POST, which was incorrect. Is now PATCH.
- The UpdateOperation call does not exist in the production version of the API, so I've removed it.
- Added the missing DeleteSubscription and PatchSubscription calls.
- Added production handling for the GetPendingOperations. There is a difference in the response between the production and the mock version of the API for some reason.
- Fixed some typoes in the exception messages
- Added a check for the Action in the Webhook.
- Added some missing properties to the Subscription model (AutoRenew, Created)
- Fixed the Pid property of the MicrosoftUser model (should be "puid")
- Added enum type for the MicrosoftWebhookPayload Action property
- Added tests for the new service methods